### PR TITLE
Fix a bug in collas2023_conference.sty for the camera-ready version

### DIFF
--- a/collas2023_conference.sty
+++ b/collas2023_conference.sty
@@ -113,6 +113,7 @@
             \begin{tabular}[t]{l}\bf\rule{\z@}{24pt}\ignorespaces}%
     \begin{tabular}[t]{l}\bf\rule{\z@}{24pt}Anonymous authors\\Paper under double-blind review\end{tabular}%
 \fi
+\fi
 \vskip 0.3in minus 0.1in}}
 
 \renewenvironment{abstract}{\vskip.075in\centerline{\large\sc


### PR DESCRIPTION
If \collasfinalcopy is uncommented, it will cause an error. Here is the quick fix: add the missing "\fi" in the nested if-else statement.